### PR TITLE
fix bug related to executing alternative rule 

### DIFF
--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -361,8 +361,8 @@ Interpreter.prototype.sampling = function(name, retry) {
   
   // if achieved maxdepth
   if (chosen.maxdepth && chosen.maxdepth < this.rules[name].depth) {
-    if (this.rules[name].depth >= chosen.maxdepth) return false;
     if (chosen.alternate) return this.sampling(chosen.alternate);
+    if (this.rules[name].depth >= chosen.maxdepth) return false;
     if (this.depth < chosen.maxdepth) return chosen;
     return false;
   }


### PR DESCRIPTION
resolving #47 .

```
6 * { ry 60 } r
  rule r md 5 > k {
  sphere
  {x 2}r
}
rule k md 4 {
  box
  {y 2}k
}
```

![eisenscript](https://cloud.githubusercontent.com/assets/678921/19620670/1deceb12-98bd-11e6-8dfd-dfa3e52f0bec.png)
