### PR TITLE
fix gulp serve error

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -55,7 +55,7 @@ gulp.task('serve', () => {
 
   gulp.watch([
     'src/**/*'
-  ], ['webpack']);
+  ], gulp.series('webpack'));
 
   gulp.watch([
     'app/tests/**/*',


### PR DESCRIPTION
```
% $(npm bin)/gulp serve
[21:03:46] Using gulpfile ~/Desktop/eisenscript/gulpfile.js
[21:03:46] Starting 'serve'...
[21:03:46] 'serve' errored after 26 ms
[21:03:46] Error: watching src/**/*: watch task has to be a function (optionally generated by using gulp.parallel or gulp.series)
    at Gulp.watch (/Users/satoshi/Desktop/eisenscript/node_modules/gulp/index.js:28:11)
    at gulp.task (/Users/satoshi/Desktop/eisenscript/gulpfile.js:56:8)
    at taskWrapper (/Users/satoshi/Desktop/eisenscript/node_modules/undertaker/lib/set-task.js:13:15)
    at bound (domain.js:395:14)
    at runBound (domain.js:408:12)
    at asyncRunner (/Users/satoshi/Desktop/eisenscript/node_modules/async-done/index.js:55:18)
```